### PR TITLE
feat: add trip stop and deprecate location

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ node_modules
 
 .env
 dist
+
+.vibe

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 dist
 
 .vibe
+docs

--- a/models/tripModel.mjs
+++ b/models/tripModel.mjs
@@ -1,5 +1,6 @@
 import mongoose from "mongoose";
 import locationSchema from "./locationModel.mjs";
+import tripStopSchema from "./tripStopModel.mjs";
 
 const tripSchema = new mongoose.Schema({
     name: {
@@ -7,7 +8,7 @@ const tripSchema = new mongoose.Schema({
         required: true,
         maxLength: 50,
     },
-    description : {
+    description: {
         type: String,
         required: false,
         maxLength: 500
@@ -30,23 +31,33 @@ const tripSchema = new mongoose.Schema({
     },
     location: {
         type: locationSchema,
-        required: false
+        required: false,
+        deprecated: true
     },
-    isPrivate : {
+    stops: {
+        type: [tripStopSchema],
+        validate: {
+            validator: function (stops) {
+                return stops.length <= 50;
+            },
+            message: "A trip cannot have more than 50 stops.",
+        },
+    },
+    isPrivate: {
         type: Boolean,
         default: false,
     },
     splittingLink: {
-        type : {
+        type: {
             url: {
-                type: String, 
-                required : false
+                type: String,
+                required: false
             },
             icon: {
                 type: String,
                 required: false
             },
-            title : {
+            title: {
                 type: String,
                 required: false
             }

--- a/models/tripModel.mjs
+++ b/models/tripModel.mjs
@@ -29,10 +29,10 @@ const tripSchema = new mongoose.Schema({
         type: Date,
         required: false,
     },
+    // Deprecated
     location: {
         type: locationSchema,
         required: false,
-        deprecated: true
     },
     stops: {
         type: [tripStopSchema],

--- a/models/tripStopModel.mjs
+++ b/models/tripStopModel.mjs
@@ -1,0 +1,17 @@
+import mongoose from "mongoose";
+import locationSchema from "./locationModel.mjs";
+
+const tripStopSchema = new mongoose.Schema({
+    name: {
+        type: String,
+        required: true,
+        maxLength: 100,
+    },
+    location: {
+        type: locationSchema,
+        required: false,
+    },
+    // Future fields (e.g., duration, order, notes)
+});
+
+export default tripStopSchema;

--- a/routes/index.mjs
+++ b/routes/index.mjs
@@ -1,5 +1,6 @@
 import express from "express";
 import trips from "./trips.mjs";
+import tripStops from "./tripStops.mjs";
 import messages from "./messages.mjs";
 import tokens from "./tokens.mjs";
 import events from "./events.mjs";
@@ -11,6 +12,7 @@ import geocode from "./geocode.mjs";
 const app = express();
 
 app.use("/trips", trips);
+app.use(tripStops);
 app.use(messages)
 
 

--- a/routes/tripStops.mjs
+++ b/routes/tripStops.mjs
@@ -1,0 +1,46 @@
+import express from "express";
+import {
+  getTripStop,
+  createTripStop,
+  deleteTripStop,
+  updateTripStop,
+  getTripStops,
+} from "../services/tripStopService.mjs";
+
+const app = express();
+
+// Get all stops for a trip
+app.get("/trips/:tripId/stops", async (req, res) => {
+  const stops = await getTripStops(req.params.tripId);
+  return res.status(200).json(stops);
+});
+
+// Get a specific stop
+app.get("/trips/:tripId/stops/:stopId", async (req, res) => {
+  const stop = await getTripStop(req.params.tripId, req.params.stopId);
+  return res.status(200).json(stop);
+});
+
+// Create a new stop
+app.post("/trips/:tripId/stops", async (req, res) => {
+  const stop = await createTripStop(req.params.tripId, req.body);
+  return res.status(201).json(stop);
+});
+
+// Update a stop
+app.put("/trips/:tripId/stops/:stopId", async (req, res) => {
+  const stop = await updateTripStop(
+    req.params.tripId,
+    req.params.stopId,
+    req.body
+  );
+  return res.status(200).json(stop);
+});
+
+// Delete a stop
+app.delete("/trips/:tripId/stops/:stopId", async (req, res) => {
+  await deleteTripStop(req.params.tripId, req.params.stopId);
+  return res.status(204).send();
+});
+
+export default app;

--- a/routes/trips.mjs
+++ b/routes/trips.mjs
@@ -14,7 +14,7 @@ app.get("/", async (req, res) => {
 });
 
 app.get("/:id", async (req, res) => {
-  const trip = await getTrip(req.params.id);
+  const trip = await getTrip(req.params.id, !!req.query?.includeStops);
 
   await trip.populate("users");
   return res.status(200).json(trip);

--- a/routes/trips.mjs
+++ b/routes/trips.mjs
@@ -14,7 +14,8 @@ app.get("/", async (req, res) => {
 });
 
 app.get("/:id", async (req, res) => {
-  const trip = await getTrip(req.params.id, !!req.query?.includeStops);
+  const includeStops = String(req.query?.includeStops).toLowerCase() === "true";
+  const trip = await getTrip(req.params.id, includeStops);
 
   await trip.populate("users");
   return res.status(200).json(trip);

--- a/services/tripService.mjs
+++ b/services/tripService.mjs
@@ -34,8 +34,11 @@ export const search = async ({ ids, search }) => {
 
 }
 
-export const getTrip = async (id) => {
-    const trip = await Trip.findById(id);
+export const getTrip = async (id, includeStops = false) => {
+    const query = Trip.findById(id);
+    if(!includeStops)
+        query.select("-stops");
+    const trip = await query.exec();
 
     if (!trip)
         throw new NotFoundError(`Cannot find trip with id ${id}`);

--- a/services/tripStopService.mjs
+++ b/services/tripStopService.mjs
@@ -1,0 +1,65 @@
+import Trip from "../models/tripModel.mjs";
+import { NotFoundError, InvalidError } from "../utils/errors.mjs";
+
+// Get all stops for a trip
+const getTripStops = async (tripId) => {
+  const trip = await Trip.findById(tripId);
+  if (!trip) throw new NotFoundError(`Trip ${tripId} not found`);
+  return trip.stops || [];
+};
+
+// Get a specific stop
+const getTripStop = async (tripId, stopId) => {
+  const trip = await Trip.findById(tripId);
+  if (!trip) throw new NotFoundError(`Trip ${tripId} not found`);
+  
+  const stop = trip.stops.id(stopId);
+  if (!stop) throw new NotFoundError(`Stop ${stopId} not found in trip ${tripId}`);
+  return stop;
+};
+
+// Create a new stop
+const createTripStop = async (tripId, stopData) => {
+  const trip = await Trip.findById(tripId);
+  if (!trip) throw new NotFoundError(`Trip ${tripId} not found`);
+  
+  // Validate stops limit (50)
+  if (trip.stops.length >= 50) {
+    throw new InvalidError("Cannot add more than 50 stops to a trip");
+  }
+  
+  trip.stops.push(stopData);
+  await trip.save();
+  return trip.stops[trip.stops.length - 1];
+};
+
+// Update a stop
+const updateTripStop = async (tripId, stopId, stopData) => {
+  const trip = await Trip.findById(tripId);
+  if (!trip) throw new NotFoundError(`Trip ${tripId} not found`);
+  
+  const stop = trip.stops.id(stopId);
+  if (!stop) throw new NotFoundError(`Stop ${stopId} not found in trip ${tripId}`);
+  
+  Object.assign(stop, stopData);
+  await trip.save();
+  return stop;
+};
+
+// Delete a stop
+const deleteTripStop = async (tripId, stopId) => {
+  const trip = await Trip.findById(tripId);
+  if (!trip) throw new NotFoundError(`Trip ${tripId} not found`);
+  
+    // Filter out the stop with the matching ID
+  trip.stops = trip.stops?.filter(stop => !stop._id.equals(stopId));
+  await trip.save();
+};
+
+export {
+  getTripStops,
+  getTripStop,
+  createTripStop,
+  updateTripStop,
+  deleteTripStop,
+};


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Trip stops management: Added endpoints to create, read, update, and delete stops within trips.
  * Optional stops inclusion: Trip retrieval now supports an `includeStops` query parameter to fetch stops alongside trip data.
  * Trip stops support a maximum of 50 stops per trip.

* **Deprecations**
  * The `location` field in trips is now deprecated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->